### PR TITLE
石の落下アニメーション・スプラッシュ・質量別波紋カラーの実装

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -64,12 +64,119 @@ let ctx = null
 let animationId = null
 let time = 0
 
-// --- 波紋管理 (#3) ---
+// --- 石管理 (#5) ---
+const stones = []
+
+function addStone(targetX, targetY, mass) {
+  stones.push({
+    x: targetX,
+    y: -20,             // 画面上部から開始
+    targetY,
+    vy: 0,              // 初速 0
+    gravity: 0.6 + mass * 0.005, // 質量で加速度を微調整
+    mass,
+    size: Math.min(4 + mass * 0.08, 12),
+    landed: false
+  })
+}
+
+function updateStones() {
+  for (let i = stones.length - 1; i >= 0; i--) {
+    const s = stones[i]
+    if (s.landed) {
+      stones.splice(i, 1)
+      continue
+    }
+    s.vy += s.gravity
+    s.y += s.vy
+    if (s.y >= s.targetY) {
+      s.y = s.targetY
+      s.landed = true
+      // 着水 → スプラッシュ + 波紋
+      addSplash(s.x, s.y, s.mass)
+      const maxRadius = Math.min(80 + s.mass * 1.5, 250)
+      addRipple(s.x, s.y, maxRadius, s.mass)
+    }
+  }
+}
+
+function drawStones() {
+  for (const s of stones) {
+    ctx.save()
+    // 石本体
+    ctx.fillStyle = '#c8d6e5'
+    ctx.beginPath()
+    ctx.arc(s.x, s.y, s.size, 0, Math.PI * 2)
+    ctx.fill()
+    // 石の影（落下方向にぼかし）
+    ctx.fillStyle = 'rgba(200, 214, 229, 0.3)'
+    ctx.beginPath()
+    ctx.arc(s.x, s.y - s.size * 1.5, s.size * 0.6, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.restore()
+  }
+}
+
+// --- スプラッシュ (#5) ---
+const splashes = []
+
+function addSplash(x, y, mass) {
+  const count = Math.min(5 + Math.floor(mass * 0.1), 15)
+  for (let i = 0; i < count; i++) {
+    const angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.5
+    const speed = 2 + Math.random() * 3
+    splashes.push({
+      x, y,
+      vx: Math.cos(angle) * speed,
+      vy: Math.sin(angle) * speed - 3 - Math.random() * 2,
+      alpha: 1,
+      size: 1.5 + Math.random() * 2
+    })
+  }
+}
+
+function updateSplashes() {
+  for (let i = splashes.length - 1; i >= 0; i--) {
+    const p = splashes[i]
+    p.x += p.vx
+    p.y += p.vy
+    p.vy += 0.15 // 重力
+    p.alpha -= 0.025
+    if (p.alpha <= 0) {
+      splashes.splice(i, 1)
+    }
+  }
+}
+
+function drawSplashes() {
+  for (const p of splashes) {
+    ctx.save()
+    ctx.globalAlpha = p.alpha
+    ctx.fillStyle = '#a0d2ff'
+    ctx.beginPath()
+    ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.restore()
+  }
+}
+
+// --- 波紋管理 (#3 + #6) ---
 const MAX_RIPPLES = 50
 const ripples = []
 
-function addRipple(x, y, maxRadius = 120) {
-  ripples.push({ x, y, radius: 2, maxRadius, alpha: 1 })
+// 質量に応じた波紋の色を返す (#6)
+function rippleColor(mass) {
+  if (mass > 80) return { r: 255, g: 100, b: 100 } // 熱い赤
+  if (mass > 50) return { r: 255, g: 200, b: 100 } // 暖かいオレンジ
+  if (mass > 25) return { r: 100, g: 220, b: 255 } // 水色
+  return { r: 255, g: 255, b: 255 }                 // 白（軽い）
+}
+
+function addRipple(x, y, maxRadius = 120, mass = 10) {
+  const color = rippleColor(mass)
+  // 質量が大きい → 広がる速度が遅い (#6)
+  const speed = Math.max(0.8, 2.0 - mass * 0.01)
+  ripples.push({ x, y, radius: 2, maxRadius, alpha: 1, color, speed })
   if (ripples.length > MAX_RIPPLES) {
     ripples.shift()
   }
@@ -78,7 +185,7 @@ function addRipple(x, y, maxRadius = 120) {
 function updateRipples() {
   for (let i = ripples.length - 1; i >= 0; i--) {
     const r = ripples[i]
-    r.radius += 1.5
+    r.radius += r.speed
     r.alpha = 1 - r.radius / r.maxRadius
     if (r.radius >= r.maxRadius) {
       ripples.splice(i, 1)
@@ -88,9 +195,10 @@ function updateRipples() {
 
 function drawRipples() {
   for (const r of ripples) {
+    const { r: cr, g: cg, b: cb } = r.color
     ctx.save()
     ctx.globalAlpha = r.alpha * 0.8
-    ctx.strokeStyle = '#ffffff'
+    ctx.strokeStyle = `rgb(${cr}, ${cg}, ${cb})`
     ctx.lineWidth = 2
     ctx.beginPath()
     ctx.arc(r.x, r.y, r.radius, 0, Math.PI * 2)
@@ -143,8 +251,12 @@ function animate() {
   time++
   ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
   drawBackground()
+  updateStones()
+  updateSplashes()
   updateRipples()
   drawRipples()
+  drawSplashes()
+  drawStones()
   animationId = requestAnimationFrame(animate)
 }
 
@@ -176,7 +288,7 @@ const handleCanvasClick = (event) => {
   const rect = canvas.value.getBoundingClientRect()
   const x = event.clientX - rect.left
   const y = event.clientY - rect.top
-  addRipple(x, y)
+  addRipple(x, y, 120, 10)
 }
 
 // --- 投稿 (#4) + Gravity API通信 (#10) ---
@@ -208,13 +320,11 @@ const submitPost = async () => {
     lastMass.value = mass
     lastGravity.value = gravity
 
-    // 質量に応じた波紋サイズ (mass: 0~100+ → maxRadius: 80~250)
-    const maxRadius = Math.min(80 + mass * 1.5, 250)
-
+    // 石を落下させる（着水後に波紋が自動発生）
     if (canvas.value) {
       const x = Math.random() * canvas.value.width * 0.6 + canvas.value.width * 0.2
       const y = Math.random() * canvas.value.height * 0.6 + canvas.value.height * 0.2
-      addRipple(x, y, maxRadius)
+      addStone(x, y, mass)
     }
 
     postCount.value++


### PR DESCRIPTION
## Summary
- 投稿時に石が画面上部から落下し、水面に着水するアニメーションを追加
- 着水時に水しぶき（スプラッシュパーティクル）が飛び散るエフェクト
- 質量に応じて波紋の色が変化（白→水色→オレンジ→赤）
- 重い石ほど波紋がゆっくり広がり、大きくなる
- 石のサイズ・落下速度・スプラッシュ粒子数も質量で変化

## Related Issues
Closes #5, Closes #6

## Test plan
- [ ] 投稿すると石が上から落ちてくることを確認
- [ ] 着水時に水しぶきが飛び散ることを確認
- [ ] 短いテキスト（軽い）→ 白い小さな波紋、速く消える
- [ ] 長いテキスト＋感嘆符（重い）→ 赤/オレンジの大きな波紋、ゆっくり広がる
- [ ] Canvasクリックの波紋は従来通り白で動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)