### PR TITLE
feat: Three.jsによる3D水面可視化

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,429 @@
+{
+  "name": "hackz-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hackz-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "three": "^0.183.2",
+        "vue": "^3.4.0"
+      },
+      "devDependencies": {
+        "@vitejs/plugin-vue": "^5.0.0",
+        "vite": "^5.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/shared": "3.5.30",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@vue/compiler-core": "3.5.30",
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/shared": "3.5.30"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.30",
+        "@vue/runtime-core": "3.5.30",
+        "@vue/shared": "3.5.30",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "vue": "3.5.30"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.30",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue": {
+      "version": "3.5.30",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.30",
+        "@vue/compiler-sfc": "3.5.30",
+        "@vue/runtime-dom": "3.5.30",
+        "@vue/server-renderer": "3.5.30",
+        "@vue/shared": "3.5.30"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "three": "^0.183.2",
     "vue": "^3.4.0"
   },
   "devDependencies": {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,16 +1,12 @@
 <template>
   <div class="container">
     <div class="header">
-      <h1>🌊 いい波立ってんね～ 🌬️</h1>
+      <h1>いい波立ってんね～</h1>
       <p>議論が波紋となり、風となって拡散される</p>
     </div>
 
     <div class="main-content">
-      <canvas
-        ref="canvas"
-        class="wave-canvas"
-        @click="handleCanvasClick"
-      ></canvas>
+      <div ref="threeContainer" class="three-canvas" @click="handleClick"></div>
 
       <div class="sidebar">
         <div class="input-section">
@@ -31,7 +27,7 @@
               class="submit-btn"
               :disabled="isSubmitting || !postText.trim() || postText.length > 500"
             >
-              {{ isSubmitting ? '投じ中...' : '石を投じる' }}
+              {{ isSubmitting ? '投じ中...' : '一石を投じる' }}
             </button>
           </div>
           <p v-if="lastMass !== null" class="mass-result">
@@ -51,8 +47,9 @@
 
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
+import * as THREE from 'three'
 
-const canvas = ref(null)
+const threeContainer = ref(null)
 const postText = ref('')
 const postCount = ref(0)
 const apiStatus = ref('確認中...')
@@ -60,339 +57,507 @@ const isSubmitting = ref(false)
 const lastMass = ref(null)
 const lastGravity = ref(null)
 
-let ctx = null
+// --- Three.js 変数 ---
+let scene, camera, renderer, clock
+let waterMesh, waterGeo
 let animationId = null
-let time = 0
+const WATER_SEG = 128
+const WATER_SIZE = 40
 
-// --- 腕 + 石の投げアニメーション ---
-let throwAnim = null
-
-function startThrow(targetX, targetY, mass) {
-  const h = canvas.value.height
-  throwAnim = {
-    phase: 'swing',   // swing → fly → done
-    progress: 0,
-    targetX,
-    targetY,
-    mass,
-    stoneSize: Math.min(5 + mass * 0.08, 12),
-    // 腕の付け根
-    baseX: 30,
-    baseY: h - 30,
-  }
-}
-
-// 腕の手の位置を計算（swingの進行度に応じた角度）
-function getHandPos(anim) {
-  const angle = -Math.PI * 0.65 + anim.progress * Math.PI * 0.85
-  const upperLen = 55
-  const foreLen = 55
-  const elbowX = anim.baseX + Math.cos(angle - 0.3) * upperLen
-  const elbowY = anim.baseY + Math.sin(angle - 0.3) * upperLen
-  const handX = elbowX + Math.cos(angle + 0.2) * foreLen
-  const handY = elbowY + Math.sin(angle + 0.2) * foreLen
-  return { elbowX, elbowY, handX, handY }
-}
-
-function updateThrowAnim() {
-  if (!throwAnim) return
-  const a = throwAnim
-
-  if (a.phase === 'swing') {
-    a.progress += 0.05
-    if (a.progress >= 1) {
-      // 石を放つ → fly フェーズへ
-      const { handX, handY } = getHandPos(a)
-      a.phase = 'fly'
-      a.progress = 0
-      a.stoneStartX = handX
-      a.stoneStartY = handY
-      // 放物線の頂点（手と着水点の中間の上方）
-      a.stonePeakX = (handX + a.targetX) / 2
-      a.stonePeakY = Math.min(handY, a.targetY) - 120 - a.mass * 0.3
-      a.armFade = 1 // 腕のフェードアウト用
-    }
-  } else if (a.phase === 'fly') {
-    a.progress += 0.03
-    a.armFade = Math.max(0, a.armFade - 0.06)
-    if (a.progress >= 1) {
-      // 着水
-      addSplash(a.targetX, a.targetY, a.mass)
-      const maxRadius = Math.min(80 + a.mass * 1.5, 250)
-      addRipple(a.targetX, a.targetY, maxRadius, a.mass)
-      throwAnim = null
-    }
-  }
-}
-
-// 二次ベジェ曲線上の点
-function bezier(t, p0, p1, p2) {
-  const u = 1 - t
-  return u * u * p0 + 2 * u * t * p1 + t * t * p2
-}
-
-function drawThrowAnim() {
-  if (!throwAnim) return
-  const a = throwAnim
-
-  ctx.save()
-
-  // --- 腕の描画 ---
-  let armAlpha = 1
-  let armProgress = a.phase === 'swing' ? a.progress : 1
-  if (a.phase === 'fly') armAlpha = a.armFade
-
-  if (armAlpha > 0) {
-    ctx.globalAlpha = armAlpha
-    const swingAngle = -Math.PI * 0.65 + armProgress * Math.PI * 0.85
-    const upperLen = 55
-    const foreLen = 55
-    const elbowX = a.baseX + Math.cos(swingAngle - 0.3) * upperLen
-    const elbowY = a.baseY + Math.sin(swingAngle - 0.3) * upperLen
-    const handX = elbowX + Math.cos(swingAngle + 0.2) * foreLen
-    const handY = elbowY + Math.sin(swingAngle + 0.2) * foreLen
-
-    // 上腕
-    ctx.strokeStyle = '#f0c8a0'
-    ctx.lineWidth = 14
-    ctx.lineCap = 'round'
-    ctx.beginPath()
-    ctx.moveTo(a.baseX, a.baseY)
-    ctx.lineTo(elbowX, elbowY)
-    ctx.stroke()
-
-    // 前腕
-    ctx.beginPath()
-    ctx.moveTo(elbowX, elbowY)
-    ctx.lineTo(handX, handY)
-    ctx.stroke()
-
-    // 手
-    ctx.fillStyle = '#f0c8a0'
-    ctx.beginPath()
-    ctx.arc(handX, handY, 10, 0, Math.PI * 2)
-    ctx.fill()
-
-    ctx.globalAlpha = 1
-  }
-
-  // --- 石の描画 ---
-  let stoneX, stoneY
-  if (a.phase === 'swing') {
-    // 手に持っている
-    const { handX, handY } = getHandPos(a)
-    stoneX = handX
-    stoneY = handY - 14
-  } else if (a.phase === 'fly') {
-    // ベジェ曲線で飛行
-    stoneX = bezier(a.progress, a.stoneStartX, a.stonePeakX, a.targetX)
-    stoneY = bezier(a.progress, a.stoneStartY, a.stonePeakY, a.targetY)
-  }
-
-  if (stoneX !== undefined) {
-    ctx.fillStyle = '#c8d6e5'
-    ctx.beginPath()
-    ctx.arc(stoneX, stoneY, a.stoneSize, 0, Math.PI * 2)
-    ctx.fill()
-
-    // 飛行中の残像
-    if (a.phase === 'fly' && a.progress > 0.05) {
-      const prevT = a.progress - 0.05
-      const prevX = bezier(prevT, a.stoneStartX, a.stonePeakX, a.targetX)
-      const prevY = bezier(prevT, a.stoneStartY, a.stonePeakY, a.targetY)
-      ctx.globalAlpha = 0.3
-      ctx.beginPath()
-      ctx.arc(prevX, prevY, a.stoneSize * 0.6, 0, Math.PI * 2)
-      ctx.fill()
-    }
-  }
-
-  ctx.restore()
-}
-
-// --- スプラッシュ (#5) ---
-const splashes = []
-
-function addSplash(x, y, mass) {
-  const count = Math.min(5 + Math.floor(mass * 0.1), 15)
-  for (let i = 0; i < count; i++) {
-    const angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.5
-    const speed = 2 + Math.random() * 3
-    splashes.push({
-      x, y,
-      vx: Math.cos(angle) * speed,
-      vy: Math.sin(angle) * speed - 3 - Math.random() * 2,
-      alpha: 1,
-      size: 1.5 + Math.random() * 2
-    })
-  }
-}
-
-function updateSplashes() {
-  for (let i = splashes.length - 1; i >= 0; i--) {
-    const p = splashes[i]
-    p.x += p.vx
-    p.y += p.vy
-    p.vy += 0.15 // 重力
-    p.alpha -= 0.025
-    if (p.alpha <= 0) {
-      splashes.splice(i, 1)
-    }
-  }
-}
-
-function drawSplashes() {
-  for (const p of splashes) {
-    ctx.save()
-    ctx.globalAlpha = p.alpha
-    ctx.fillStyle = '#a0d2ff'
-    ctx.beginPath()
-    ctx.arc(p.x, p.y, p.size, 0, Math.PI * 2)
-    ctx.fill()
-    ctx.restore()
-  }
-}
-
-// --- 波紋管理 (#3 + #6) ---
-const MAX_RIPPLES = 50
+// 石（投稿）の3Dオブジェクト
+const stoneMeshes = []
+// 波紋データ
 const ripples = []
+// スプラッシュパーティクル
+let splashParticles = null
+let splashData = []
+// 飛行中の石
+let flyingStone = null
 
-// 質量に応じた波紋の色を返す (#6)
-function rippleColor(mass) {
-  if (mass > 80) return { r: 255, g: 100, b: 100 } // 熱い赤
-  if (mass > 50) return { r: 255, g: 200, b: 100 } // 暖かいオレンジ
-  if (mass > 25) return { r: 100, g: 220, b: 255 } // 水色
-  return { r: 255, g: 255, b: 255 }                 // 白（軽い）
+// --- 投稿データ管理 ---
+const posts = ref([])
+
+function loadMockPosts() {
+  posts.value = [
+    { id: 1, text: 'SNSの即時性は本当に必要なのか？', x: -0.4, z: -0.3, mass: 65, heat: 40, weathered: 0.0 },
+    { id: 2, text: 'もっとゆっくり議論したい', x: 0.2, z: 0.2, mass: 30, heat: 10, weathered: 0.2 },
+    { id: 3, text: '炎上は現代の焚き火である！！', x: 0.0, z: -0.1, mass: 85, heat: 70, weathered: 0.0 },
+    { id: 4, text: 'エコーチェンバーを壊すには', x: 0.35, z: 0.3, mass: 45, heat: 25, weathered: 0.4 },
+  ]
 }
 
-function addRipple(x, y, maxRadius = 120, mass = 10) {
-  const color = rippleColor(mass)
-  // 質量が大きい → 広がる速度が遅い (#6)
-  const speed = Math.max(0.8, 2.0 - mass * 0.01)
-  ripples.push({ x, y, radius: 2, maxRadius, alpha: 1, color, speed })
-  if (ripples.length > MAX_RIPPLES) {
-    ripples.shift()
+// --- 質量→色 ---
+function massColor(mass) {
+  if (mass > 80) return new THREE.Color(1.0, 0.3, 0.3)
+  if (mass > 50) return new THREE.Color(1.0, 0.75, 0.3)
+  if (mass > 25) return new THREE.Color(0.3, 0.85, 1.0)
+  return new THREE.Color(0.9, 0.9, 1.0)
+}
+
+// --- Three.js 初期化 ---
+function initThree() {
+  const container = threeContainer.value
+  const w = container.clientWidth
+  const h = container.clientHeight
+
+  // シーン
+  scene = new THREE.Scene()
+  scene.fog = new THREE.FogExp2(0x0a1628, 0.015)
+
+  // カメラ（斜め上から水面を見下ろす）
+  camera = new THREE.PerspectiveCamera(55, w / h, 0.1, 200)
+  camera.position.set(0, 18, 22)
+  camera.lookAt(0, 0, 0)
+
+  // レンダラー
+  renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true })
+  renderer.setSize(w, h)
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2))
+  renderer.toneMapping = THREE.ACESFilmicToneMapping
+  renderer.toneMappingExposure = 1.2
+  container.appendChild(renderer.domElement)
+
+  clock = new THREE.Clock()
+
+  // ライティング
+  const ambientLight = new THREE.AmbientLight(0x334466, 0.8)
+  scene.add(ambientLight)
+
+  const moonLight = new THREE.DirectionalLight(0xaaccff, 1.5)
+  moonLight.position.set(-10, 20, 10)
+  scene.add(moonLight)
+
+  const warmLight = new THREE.PointLight(0xff8844, 0.6, 50)
+  warmLight.position.set(5, 8, -5)
+  scene.add(warmLight)
+
+  // 水面メッシュ
+  waterGeo = new THREE.PlaneGeometry(WATER_SIZE, WATER_SIZE, WATER_SEG, WATER_SEG)
+  const waterMat = new THREE.MeshPhongMaterial({
+    color: 0x1a4a8a,
+    emissive: 0x0a1a3a,
+    specular: 0x88bbff,
+    shininess: 80,
+    transparent: true,
+    opacity: 0.85,
+    side: THREE.DoubleSide,
+    flatShading: false,
+  })
+  waterMesh = new THREE.Mesh(waterGeo, waterMat)
+  waterMesh.rotation.x = -Math.PI / 2
+  scene.add(waterMesh)
+
+  // 水底のグリッド
+  const gridHelper = new THREE.GridHelper(WATER_SIZE, 30, 0x112244, 0x112244)
+  gridHelper.position.y = -2
+  gridHelper.material.opacity = 0.15
+  gridHelper.material.transparent = true
+  scene.add(gridHelper)
+
+  // 背景の空（暗い夜空）
+  scene.background = new THREE.Color(0x0a1628)
+
+  // スプラッシュ用パーティクルシステム
+  const splashGeo = new THREE.BufferGeometry()
+  const maxSplash = 300
+  const splashPositions = new Float32Array(maxSplash * 3)
+  const splashAlphas = new Float32Array(maxSplash)
+  splashGeo.setAttribute('position', new THREE.BufferAttribute(splashPositions, 3))
+  splashGeo.setAttribute('alpha', new THREE.BufferAttribute(splashAlphas, 1))
+  const splashMat = new THREE.PointsMaterial({
+    color: 0xaaddff,
+    size: 0.15,
+    transparent: true,
+    opacity: 0.8,
+    depthWrite: false,
+  })
+  splashParticles = new THREE.Points(splashGeo, splashMat)
+  scene.add(splashParticles)
+
+  // 初期の石を配置
+  createStoneMeshes()
+}
+
+// --- 石の3Dメッシュ生成 ---
+function createStoneMeshes() {
+  // 既存の石を削除
+  for (const s of stoneMeshes) {
+    scene.remove(s.group)
+  }
+  stoneMeshes.length = 0
+
+  for (const p of posts.value) {
+    addStoneMesh(p)
   }
 }
 
-function updateRipples() {
+function addStoneMesh(p) {
+  const group = new THREE.Group()
+
+  const size = 0.3 + p.mass * 0.005
+  const color = massColor(p.mass)
+
+  // 石本体（変形した球体 → 石っぽく）
+  const stoneGeo = new THREE.DodecahedronGeometry(size, 1)
+  const stoneMat = new THREE.MeshPhongMaterial({
+    color: color,
+    emissive: color.clone().multiplyScalar(p.heat > 30 ? 0.3 : 0.05),
+    specular: 0x666666,
+    shininess: 40,
+    transparent: true,
+    opacity: Math.max(0.4, 1 - p.weathered),
+  })
+  const stoneMesh = new THREE.Mesh(stoneGeo, stoneMat)
+  group.add(stoneMesh)
+
+  // 熱量が高い石にはグローリング
+  if (p.heat > 20) {
+    const glowGeo = new THREE.RingGeometry(size + 0.2, size + 0.5, 32)
+    const glowMat = new THREE.MeshBasicMaterial({
+      color: color,
+      transparent: true,
+      opacity: 0.3,
+      side: THREE.DoubleSide,
+    })
+    const glowMesh = new THREE.Mesh(glowGeo, glowMat)
+    glowMesh.rotation.x = -Math.PI / 2
+    glowMesh.position.y = 0.05
+    glowMesh.userData.isGlow = true
+    group.add(glowMesh)
+  }
+
+  // テキストラベル（Sprite）
+  const label = p.text.length > 16 ? p.text.slice(0, 16) + '…' : p.text
+  const sprite = createTextSprite(label, color)
+  sprite.position.y = size + 0.6
+  group.add(sprite)
+
+  // 配置
+  const wx = p.x * (WATER_SIZE / 2) * 0.8
+  const wz = p.z * (WATER_SIZE / 2) * 0.8
+  group.position.set(wx, 0.2, wz)
+
+  scene.add(group)
+  stoneMeshes.push({ group, post: p, baseY: 0.2 })
+}
+
+function createTextSprite(text, color) {
+  const canvas = document.createElement('canvas')
+  const ctx = canvas.getContext('2d')
+  canvas.width = 512
+  canvas.height = 64
+
+  // 背景
+  ctx.fillStyle = 'rgba(0, 0, 0, 0.6)'
+  ctx.roundRect(0, 0, canvas.width, canvas.height, 8)
+  ctx.fill()
+
+  // テキスト
+  ctx.fillStyle = '#ffffff'
+  ctx.font = 'bold 28px sans-serif'
+  ctx.textAlign = 'center'
+  ctx.textBaseline = 'middle'
+  ctx.fillText(text, canvas.width / 2, canvas.height / 2)
+
+  const texture = new THREE.CanvasTexture(canvas)
+  const mat = new THREE.SpriteMaterial({
+    map: texture,
+    transparent: true,
+    depthWrite: false,
+  })
+  const sprite = new THREE.Sprite(mat)
+  sprite.scale.set(4, 0.5, 1)
+  return sprite
+}
+
+// --- 水面の波アニメーション ---
+// PlaneGeometryはXY平面で生成され、rotation.x=-PI/2でXZ平面に回転
+// ジオメトリのローカル座標: X→ワールドX, Y→ワールド-Z（回転により反転）
+function updateWater(elapsed) {
+  const positions = waterGeo.attributes.position
+  const count = positions.count
+
+  for (let i = 0; i < count; i++) {
+    const localX = positions.getX(i)  // ワールドX
+    const localY = positions.getY(i)  // ワールド-Z（回転でZが反転）
+
+    // 基本の波
+    let h = Math.sin(localX * 0.5 + elapsed * 0.8) * 0.15
+      + Math.sin(localY * 0.3 + elapsed * 0.6) * 0.1
+      + Math.sin((localX + localY) * 0.4 + elapsed * 1.2) * 0.08
+
+    // 波紋による変位
+    // ワールド座標の波紋(r.x, r.z)をローカル座標に変換: localX=r.x, localY=-r.z
+    for (const r of ripples) {
+      const dx = localX - r.x
+      const dy = localY - (-r.z)  // ワールドZ → ローカルY = -Z
+      const dist = Math.sqrt(dx * dx + dy * dy)
+      if (dist < r.radius + 2 && dist > r.radius - 2) {
+        const wave = Math.sin((dist - r.radius) * 3) * r.amplitude
+        h += wave
+      }
+    }
+
+    positions.setZ(i, h)
+  }
+
+  positions.needsUpdate = true
+  waterGeo.computeVertexNormals()
+}
+
+// --- 波紋 ---
+function addRipple3D(worldX, worldZ, mass) {
+  const amplitude = 0.1 + mass * 0.005
+  const maxRadius = 3 + mass * 0.08
+  ripples.push({
+    x: worldX,
+    z: worldZ,
+    radius: 0.1,
+    maxRadius,
+    amplitude,
+    speed: Math.max(1.5, 4 - mass * 0.02),
+  })
+}
+
+function updateRipples(dt) {
   for (let i = ripples.length - 1; i >= 0; i--) {
     const r = ripples[i]
-    r.radius += r.speed
-    r.alpha = 1 - r.radius / r.maxRadius
-    if (r.radius >= r.maxRadius) {
+    r.radius += r.speed * dt
+    r.amplitude *= 0.995
+    if (r.radius > r.maxRadius || r.amplitude < 0.001) {
       ripples.splice(i, 1)
     }
   }
 }
 
-function drawRipples() {
-  for (const r of ripples) {
-    const { r: cr, g: cg, b: cb } = r.color
-    ctx.save()
-    ctx.globalAlpha = r.alpha * 0.8
-    ctx.strokeStyle = `rgb(${cr}, ${cg}, ${cb})`
-    ctx.lineWidth = 2
-    ctx.beginPath()
-    ctx.arc(r.x, r.y, r.radius, 0, Math.PI * 2)
-    ctx.stroke()
-    // 内側にもう一つ薄い波紋
-    if (r.radius > 10) {
-      ctx.globalAlpha = r.alpha * 0.3
-      ctx.beginPath()
-      ctx.arc(r.x, r.y, r.radius * 0.6, 0, Math.PI * 2)
-      ctx.stroke()
-    }
-    ctx.restore()
+// --- スプラッシュ ---
+function addSplash3D(worldX, worldZ, mass) {
+  const count = Math.min(8 + Math.floor(mass * 0.15), 30)
+  for (let i = 0; i < count; i++) {
+    const angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.5
+    const speed = 1 + Math.random() * 3
+    splashData.push({
+      x: worldX,
+      y: 0.2,
+      z: worldZ,
+      vx: Math.cos(angle) * speed * 0.3,
+      vy: 2 + Math.random() * 4,
+      vz: Math.sin(angle) * speed * 0.3,
+      life: 1,
+    })
   }
 }
 
-// --- 背景描画 (#1) ---
-function drawBackground() {
-  const w = canvas.value.width
-  const h = canvas.value.height
+function updateSplashes(dt) {
+  for (let i = splashData.length - 1; i >= 0; i--) {
+    const s = splashData[i]
+    s.x += s.vx * dt
+    s.y += s.vy * dt
+    s.z += s.vz * dt
+    s.vy -= 9.8 * dt
+    s.life -= dt * 1.5
+    if (s.life <= 0 || s.y < -1) {
+      splashData.splice(i, 1)
+    }
+  }
 
-  // 水面グラデーション
-  const grad = ctx.createLinearGradient(0, 0, 0, h)
-  grad.addColorStop(0, '#1a2a6c')
-  grad.addColorStop(0.5, '#2d4a8a')
-  grad.addColorStop(1, '#1a3a5c')
-  ctx.fillStyle = grad
-  ctx.fillRect(0, 0, w, h)
+  // パーティクルバッファ更新
+  const positions = splashParticles.geometry.attributes.position
+  for (let i = 0; i < 300; i++) {
+    if (i < splashData.length) {
+      positions.setXYZ(i, splashData[i].x, splashData[i].y, splashData[i].z)
+    } else {
+      positions.setXYZ(i, 0, -100, 0)
+    }
+  }
+  positions.needsUpdate = true
+}
 
-  // 波打つ水面の横線
-  ctx.strokeStyle = 'rgba(255, 255, 255, 0.05)'
-  ctx.lineWidth = 1
-  for (let y = 30; y < h; y += 40) {
-    ctx.beginPath()
-    for (let x = 0; x <= w; x += 5) {
-      const offsetY = Math.sin((x + time * 30) * 0.02) * 4
-        + Math.sin((x + time * 15) * 0.01) * 3
-      if (x === 0) {
-        ctx.moveTo(x, y + offsetY)
-      } else {
-        ctx.lineTo(x, y + offsetY)
+// --- 石の投げアニメーション ---
+function throwStone(targetX, targetZ, mass, text) {
+  const startX = -WATER_SIZE / 2 + 2
+  const startY = 8
+  const startZ = WATER_SIZE / 2 - 2
+
+  const size = 0.3 + mass * 0.005
+  const color = massColor(mass)
+  const geo = new THREE.DodecahedronGeometry(size, 1)
+  const mat = new THREE.MeshPhongMaterial({
+    color: color,
+    emissive: color.clone().multiplyScalar(0.2),
+    specular: 0x666666,
+    shininess: 40,
+  })
+  const mesh = new THREE.Mesh(geo, mat)
+  mesh.position.set(startX, startY, startZ)
+  scene.add(mesh)
+
+  // 残像用（トレイル）
+  const trailGeo = new THREE.BufferGeometry()
+  const trailPositions = new Float32Array(60 * 3)
+  trailGeo.setAttribute('position', new THREE.BufferAttribute(trailPositions, 3))
+  const trailMat = new THREE.LineBasicMaterial({
+    color: color,
+    transparent: true,
+    opacity: 0.4,
+  })
+  const trailLine = new THREE.Line(trailGeo, trailMat)
+  scene.add(trailLine)
+
+  flyingStone = {
+    mesh,
+    trailLine,
+    trailPositions: [],
+    startX, startY, startZ,
+    targetX, targetZ,
+    mass, text,
+    progress: 0,
+    peakY: startY + 3,
+  }
+}
+
+function updateFlyingStone(dt) {
+  if (!flyingStone) return
+  const f = flyingStone
+  f.progress += dt * 0.8
+
+  if (f.progress >= 1) {
+    // 着水
+    scene.remove(f.mesh)
+    scene.remove(f.trailLine)
+
+    addSplash3D(f.targetX, f.targetZ, f.mass)
+    addRipple3D(f.targetX, f.targetZ, f.mass)
+
+    // 石を配置
+    const newPost = {
+      id: Date.now(),
+      text: f.text,
+      x: f.targetX / (WATER_SIZE / 2) / 0.8,
+      z: f.targetZ / (WATER_SIZE / 2) / 0.8,
+      mass: f.mass,
+      heat: 0,
+      weathered: 0,
+    }
+    posts.value.push(newPost)
+    addStoneMesh(newPost)
+
+    flyingStone = null
+    return
+  }
+
+  // ベジェ補間
+  const t = f.progress
+  const u = 1 - t
+  const midX = (f.startX + f.targetX) / 2
+  const midZ = (f.startZ + f.targetZ) / 2
+
+  f.mesh.position.x = u * u * f.startX + 2 * u * t * midX + t * t * f.targetX
+  f.mesh.position.z = u * u * f.startZ + 2 * u * t * midZ + t * t * f.targetZ
+  f.mesh.position.y = u * u * f.startY + 2 * u * t * f.peakY + t * t * 0.3
+  f.mesh.rotation.x += dt * 5
+  f.mesh.rotation.z += dt * 3
+
+  // トレイル更新
+  f.trailPositions.push(f.mesh.position.x, f.mesh.position.y, f.mesh.position.z)
+  if (f.trailPositions.length > 60 * 3) {
+    f.trailPositions.splice(0, 3)
+  }
+  const positions = f.trailLine.geometry.attributes.position
+  for (let i = 0; i < 60; i++) {
+    const idx = i * 3
+    if (idx < f.trailPositions.length) {
+      positions.setXYZ(i, f.trailPositions[idx], f.trailPositions[idx + 1], f.trailPositions[idx + 2])
+    }
+  }
+  positions.needsUpdate = true
+  f.trailLine.geometry.setDrawRange(0, Math.floor(f.trailPositions.length / 3))
+}
+
+// --- 石のボブ（浮遊）アニメーション ---
+function updateStones(elapsed) {
+  for (const s of stoneMeshes) {
+    // 水面に浮くようにゆっくり上下
+    s.group.position.y = s.baseY + Math.sin(elapsed * 1.5 + s.post.id * 0.7) * 0.1
+
+    // 熱量が高い石のグロー脈動
+    if (s.post.heat > 20) {
+      for (const child of s.group.children) {
+        if (child.userData.isGlow) {
+          child.material.opacity = 0.15 + Math.sin(elapsed * 3 + s.post.id) * 0.15
+          child.scale.setScalar(1 + Math.sin(elapsed * 2 + s.post.id) * 0.1)
+        }
       }
     }
-    ctx.stroke()
+  }
+}
+
+// --- クリック → 波紋 ---
+function handleClick(event) {
+  const container = threeContainer.value
+  const rect = container.getBoundingClientRect()
+  const mouse = new THREE.Vector2(
+    ((event.clientX - rect.left) / rect.width) * 2 - 1,
+    -((event.clientY - rect.top) / rect.height) * 2 + 1,
+  )
+
+  const raycaster = new THREE.Raycaster()
+  raycaster.setFromCamera(mouse, camera)
+  const intersects = raycaster.intersectObject(waterMesh)
+  if (intersects.length > 0) {
+    const point = intersects[0].point
+    addRipple3D(point.x, point.z, 15)
+    addSplash3D(point.x, point.z, 10)
   }
 }
 
 // --- メインループ ---
 function animate() {
-  if (!ctx) return
-  time++
-  ctx.clearRect(0, 0, canvas.value.width, canvas.value.height)
-  drawBackground()
-  updateThrowAnim()
-  updateSplashes()
-  updateRipples()
-  drawRipples()
-  drawSplashes()
-  drawThrowAnim()
   animationId = requestAnimationFrame(animate)
+  const dt = Math.min(clock.getDelta(), 0.05)
+  const elapsed = clock.getElapsedTime()
+
+  updateWater(elapsed)
+  updateRipples(dt)
+  updateSplashes(dt)
+  updateStones(elapsed)
+  updateFlyingStone(dt)
+
+  renderer.render(scene, camera)
 }
 
-// --- Canvas セットアップ (#1) ---
-function resizeCanvas() {
-  if (canvas.value) {
-    canvas.value.width = canvas.value.offsetWidth
-    canvas.value.height = canvas.value.offsetHeight
-  }
+// --- リサイズ ---
+function onResize() {
+  if (!threeContainer.value) return
+  const w = threeContainer.value.clientWidth
+  const h = threeContainer.value.clientHeight
+  camera.aspect = w / h
+  camera.updateProjectionMatrix()
+  renderer.setSize(w, h)
 }
 
+// --- ライフサイクル ---
 onMounted(() => {
-  if (canvas.value) {
-    ctx = canvas.value.getContext('2d')
-    resizeCanvas()
-    window.addEventListener('resize', resizeCanvas)
-    animate()
-    checkApiStatus()
-  }
+  loadMockPosts()
+  initThree()
+  animate()
+  checkApiStatus()
+  window.addEventListener('resize', onResize)
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', resizeCanvas)
+  window.removeEventListener('resize', onResize)
   if (animationId) cancelAnimationFrame(animationId)
+  if (renderer) renderer.dispose()
 })
 
-// --- イベントハンドラ (#2) ---
-const handleCanvasClick = (event) => {
-  const rect = canvas.value.getBoundingClientRect()
-  const x = event.clientX - rect.left
-  const y = event.clientY - rect.top
-  addRipple(x, y, 120, 10)
-}
-
-// --- 投稿 (#4) + Gravity API通信 (#10) ---
+// --- 投稿 ---
 const submitPost = async () => {
   if (!postText.value.trim() || postText.value.length > 500) return
-
   isSubmitting.value = true
 
   try {
-    // Gravity APIで質量を計算
-    let mass = postText.value.length * 0.1 // フォールバック値
+    let mass = postText.value.length * 0.1
     let gravity = mass * 0.1
 
     try {
@@ -413,12 +578,10 @@ const submitPost = async () => {
     lastMass.value = mass
     lastGravity.value = gravity
 
-    // 腕を振って石を投げる（着水後に波紋が自動発生）
-    if (canvas.value) {
-      const x = Math.random() * canvas.value.width * 0.5 + canvas.value.width * 0.3
-      const y = Math.random() * canvas.value.height * 0.4 + canvas.value.height * 0.2
-      startThrow(x, y, mass)
-    }
+    // ランダムな着水位置（水面中央付近）
+    const targetX = (Math.random() - 0.5) * WATER_SIZE * 0.6
+    const targetZ = (Math.random() - 0.5) * WATER_SIZE * 0.6
+    throwStone(targetX, targetZ, mass, postText.value)
 
     postCount.value++
     postText.value = ''
@@ -429,7 +592,7 @@ const submitPost = async () => {
   }
 }
 
-// --- API接続確認 (#12) ---
+// --- API接続確認 ---
 const checkApiStatus = async () => {
   try {
     await Promise.all([
@@ -437,7 +600,7 @@ const checkApiStatus = async () => {
       fetch('/api/logic/health').catch(() => { throw new Error('logic') })
     ])
     apiStatus.value = '接続済み'
-  } catch (error) {
+  } catch {
     apiStatus.value = '未接続'
   }
 }
@@ -449,41 +612,49 @@ const checkApiStatus = async () => {
   height: 100vh;
   display: flex;
   flex-direction: column;
-  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  background: #0a1628;
   overflow: hidden;
 }
 
 .header {
-  padding: 20px;
+  padding: 15px 20px;
   color: white;
   text-align: center;
-  background: rgba(0, 0, 0, 0.3);
+  background: rgba(10, 22, 40, 0.9);
+  border-bottom: 1px solid rgba(100, 180, 255, 0.15);
 }
 
 .header h1 {
-  font-size: 2.5em;
-  margin-bottom: 10px;
+  font-size: 2em;
+  margin-bottom: 4px;
+  background: linear-gradient(90deg, #4af, #a8f, #4af);
+  background-size: 200% auto;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 3s ease-in-out infinite;
+}
+
+@keyframes shimmer {
+  0%, 100% { background-position: 0% center; }
+  50% { background-position: 200% center; }
 }
 
 .header p {
-  font-size: 1.1em;
-  opacity: 0.9;
+  font-size: 0.95em;
+  opacity: 0.6;
 }
 
 .main-content {
   display: flex;
   flex: 1;
-  gap: 20px;
-  padding: 20px;
+  gap: 0;
   overflow: hidden;
+  position: relative;
 }
 
-.wave-canvas {
+.three-canvas {
   flex: 1;
   min-height: 200px;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 10px;
-  border: 2px solid rgba(255, 255, 255, 0.2);
   cursor: crosshair;
 }
 
@@ -492,24 +663,26 @@ const checkApiStatus = async () => {
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 15px;
+  padding: 15px;
+  background: rgba(10, 22, 40, 0.85);
+  border-left: 1px solid rgba(100, 180, 255, 0.1);
 }
 
 @media (max-width: 768px) {
   .main-content {
     flex-direction: column;
-    padding: 10px;
-    gap: 10px;
   }
-  .wave-canvas {
+  .three-canvas {
     flex: 1;
   }
   .sidebar {
     width: 100%;
-    flex-shrink: 1;
+    border-left: none;
+    border-top: 1px solid rgba(100, 180, 255, 0.1);
   }
   .header h1 {
-    font-size: 1.5em;
+    font-size: 1.4em;
   }
   .header {
     padding: 10px;
@@ -518,21 +691,32 @@ const checkApiStatus = async () => {
 
 .input-section,
 .info-section {
-  background: rgba(255, 255, 255, 0.1);
+  background: rgba(100, 180, 255, 0.06);
   padding: 15px;
   border-radius: 10px;
-  backdrop-filter: blur(10px);
+  border: 1px solid rgba(100, 180, 255, 0.1);
   color: white;
 }
 
 textarea {
   width: 100%;
   padding: 10px;
-  border: none;
-  border-radius: 5px;
+  border: 1px solid rgba(100, 180, 255, 0.2);
+  border-radius: 6px;
   font-family: inherit;
   resize: none;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(10, 22, 40, 0.8);
+  color: white;
+  outline: none;
+  transition: border-color 0.3s;
+}
+
+textarea:focus {
+  border-color: rgba(100, 180, 255, 0.5);
+}
+
+textarea::placeholder {
+  color: rgba(255, 255, 255, 0.3);
 }
 
 .input-footer {
@@ -544,7 +728,7 @@ textarea {
 
 .char-count {
   font-size: 0.8em;
-  opacity: 0.7;
+  opacity: 0.5;
   white-space: nowrap;
 }
 
@@ -556,23 +740,26 @@ textarea {
 .submit-btn {
   flex: 1;
   padding: 10px;
-  border: none;
-  background: #00d4ff;
-  color: #333;
+  border: 1px solid rgba(100, 180, 255, 0.3);
+  background: rgba(100, 180, 255, 0.15);
+  color: #aaddff;
   font-weight: bold;
-  border-radius: 5px;
+  border-radius: 6px;
   cursor: pointer;
   transition: all 0.3s;
+  font-size: 0.95em;
 }
 
 .submit-btn:hover:not(:disabled) {
-  background: #00f7ff;
-  transform: scale(1.05);
+  background: rgba(100, 180, 255, 0.3);
+  border-color: rgba(100, 180, 255, 0.6);
+  transform: scale(1.02);
 }
 
 .submit-btn:disabled {
-  background: #666;
-  color: #999;
+  background: rgba(50, 50, 50, 0.5);
+  color: rgba(255, 255, 255, 0.2);
+  border-color: rgba(50, 50, 50, 0.3);
   cursor: not-allowed;
   transform: none;
 }
@@ -580,17 +767,19 @@ textarea {
 .mass-result {
   margin-top: 8px;
   font-size: 0.85em;
-  opacity: 0.8;
+  opacity: 0.5;
   text-align: center;
 }
 
 .info-section h3 {
   margin-bottom: 10px;
-  font-size: 1.1em;
+  font-size: 1em;
+  opacity: 0.8;
 }
 
 .info-section p {
-  margin: 5px 0;
-  font-size: 0.95em;
+  margin: 4px 0;
+  font-size: 0.9em;
+  opacity: 0.6;
 }
 </style>


### PR DESCRIPTION
## Summary
- Canvas 2DからThree.jsへ移行し、3Dビジュアルを実装
- 水面メッシュの波動シミュレーション（頂点変位によるリアルタイム波）
- 投稿を多面体（DodecahedronGeometry）で石として表現、質量で色・サイズ変化
- パーティクルシステムによる水飛沫エフェクト
- 放物線を描く石の投げアニメーション（トレイル付き）
- クリックで波紋+飛沫が発生
- 熱量が高い投稿はグローリングが脈動
- モックデータによる既存投稿の表示（#7対応）

## Test plan
- [ ] `docker-compose up` でフロントエンドが正常起動する
- [ ] 3D水面が波打って表示される
- [ ] モックデータの4つの石がテキストラベル付きで表示される
- [ ] 水面クリックで波紋と飛沫が発生する
- [ ] 「一石を投じる」でテキスト投稿→石が飛んで着水→波紋が発生する
- [ ] モバイルレイアウトが崩れない

🤖 Generated with [Claude Code](https://claude.com/claude-code)