### PR TITLE
#19 interactions テーブルを追加し、posts との外部キー制約を設定

### DIFF
--- a/db/init.sql
+++ b/db/init.sql
@@ -20,3 +20,13 @@ CREATE TABLE IF NOT EXISTS posts (
 
 -- サンプルデータを挿入（postsテーブルに合わせて修正）
 INSERT INTO posts (text) VALUES ('環境構築テスト');
+
+-- 新しいinteractionsテーブルを作成
+CREATE TABLE IF NOT EXISTS interactions (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    post_id INT,
+    type ENUM('wave', 'wind'),
+    value FLOAT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (post_id) REFERENCES posts(id)
+);


### PR DESCRIPTION
- init.sql に interactions テーブルを定義（id, post_id, type, value, created_at）
- post_id を posts.id に外部キー参照