### PR TITLE
fix: 魚とサメが進行方向を正しく向くように修正

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1336,9 +1336,8 @@ function updateFishes(dt, elapsed) {
       f.mesh.position.z += (dz / dist) * moveSpeed
     }
 
-    // 進行方向を向く
-    const angle = Math.atan2(dx, dz)
-    f.mesh.rotation.y = angle
+    // 進行方向を向く（メッシュの頭が+X方向なので90度オフセット）
+    f.mesh.rotation.y = Math.atan2(dx, dz) - Math.PI / 2
 
     // 尾びれアニメーション
     f.tailPhase += dt * 8
@@ -1651,7 +1650,7 @@ function updateShark(dt, elapsed) {
       const spd = s.speed * 1.5 * dt
       s.mesh.position.x += (dx / dist) * spd
       s.mesh.position.z += (dz / dist) * spd
-      s.mesh.rotation.y = Math.atan2(dx, dz)
+      s.mesh.rotation.y = Math.atan2(dx, dz) - Math.PI / 2
     } else {
       // 退場完了
       scene.remove(s.mesh)
@@ -1717,7 +1716,7 @@ function updateShark(dt, elapsed) {
       s.mesh.position.x += (dx / dist) * spd
       s.mesh.position.y += (dy / dist) * spd * 0.3
       s.mesh.position.z += (dz / dist) * spd
-      s.mesh.rotation.y = Math.atan2(dx, dz)
+      s.mesh.rotation.y = Math.atan2(dx, dz) - Math.PI / 2
     }
   }
 


### PR DESCRIPTION
## Summary
- 魚とサメのメッシュが+X方向を頭としているのに対し、`atan2(dx, dz)`は+Z方向を0度とするため90度ずれてドリフト状態になっていた
- 回転角に`-Math.PI/2`のオフセットを追加して修正(魚1箇所、サメ2箇所)

## Test plan
- [ ] 魚が目標地点に向かって頭から進むことを確認
- [ ] サメが赤い魚に向かって頭から追跡することを確認
- [ ] サメの退場時も頭を進行方向に向けていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)